### PR TITLE
Add CORS methods header for generate quote PDF function

### DIFF
--- a/supabase/functions/generate-quote-pdf/index.ts
+++ b/supabase/functions/generate-quote-pdf/index.ts
@@ -5,6 +5,7 @@ import { PDFDocument, rgb, StandardFonts } from 'https://esm.sh/pdf-lib@1.17.1';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
 };
 
 interface GeneratePDFRequest {


### PR DESCRIPTION
## Summary
- add POST and OPTIONS to the Access-Control-Allow-Methods header in the generate quote PDF edge function

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4e567d0a8832bb26c9774d9826217